### PR TITLE
feat: migrate legacy apprentice program

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -11,7 +11,7 @@ export default defineUserConfig({
   theme: defaultTheme({
     logo: 'https://vuejs.press/images/hero.png',
 
-    navbar: ['/', '/ap/getting-started', '/contribute'],
+    navbar: ['/', { text: 'Legacy', link: '/legacy/roadmap' }, '/contribute'],
 
     sidebar: {
       '/': 'heading',
@@ -19,6 +19,57 @@ export default defineUserConfig({
         {
           text: 'Apprentice Program',
           children: ['/ap/getting-started.md', '/ap/todo-app.md'],
+        },
+      ],
+      '/legacy/': [
+        {
+          text: 'Legacy - AP',
+          children: [
+            '/legacy/roadmap.md',
+            '/legacy/objectives.md',
+            {
+              text: 'Modules',
+              link: '/legacy/modules/index.md',
+              children: [
+                {
+                  text: 'Enablers',
+                  children: ['/legacy/modules/enablers/create-kata-repo.md'],
+                },
+                {
+                  text: 'Katas',
+                  children: [
+                    '/legacy/modules/katas/java-8-streams.md',
+                    '/legacy/modules/katas/mars-rover.md',
+                  ],
+                },
+                {
+                  text: 'Essentials',
+                  children: [
+                    '/legacy/modules/essentials/command-line-basics.md',
+                    '/legacy/modules/essentials/learn-git-branching.md',
+                    '/legacy/modules/essentials/introduction-to-docker.md',
+                  ],
+                },
+                {
+                  text: 'Todo App',
+                  link: '/legacy/modules/todo-app/index.md',
+                  children: [
+                    '/legacy/modules/todo-app/create-github-repo.md',
+                    '/legacy/modules/todo-app/create-initial-vue3-frontend.md',
+                    '/legacy/modules/todo-app/implement-ui-design.md',
+                    '/legacy/modules/todo-app/frontend-testing-with-cypress.md',
+                    '/legacy/modules/todo-app/ensure-green-tests-and-code-quality.md',
+                    '/legacy/modules/todo-app/add-json-mock-server-for-frontend.md',
+                    '/legacy/modules/todo-app/initial-spring-boot-backend.md',
+                    '/legacy/modules/todo-app/connect-frontend-with-backend.md',
+                    '/legacy/modules/todo-app/persist-data-with-in-memory-database.md',
+                    '/legacy/modules/todo-app/database-management-with-liquibase.md',
+                    '/legacy/modules/todo-app/dockerize-the-app.md',
+                  ],
+                },
+              ],
+            },
+          ],
         },
       ],
     },

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ home: true
 title: Home
 heroImage: https://vuejs.press/images/hero.png
 actions:
-  - text: Get Started
-    link: /ap/getting-started.html
+  - text: Get-Started - Legacy
+    link: /legacy/roadmap.html
     type: primary
   - text: Contribute
     link: /contribute.html

--- a/docs/legacy/modules/enablers/create-kata-repo.md
+++ b/docs/legacy/modules/enablers/create-kata-repo.md
@@ -1,0 +1,12 @@
+# Create Kata Repository
+
+## Description
+
+During your Apprentice Programm you will solve multiple katas. Solving them will improve your skill. You gain even more if an experienced college reviews your code.
+
+Therefore, create a new repository with your own KB GitHub Account. Invite your Introducer and Mentor (if you have one, yet) as collaborator.
+
+## Acceptance Criteria
+
+- #AC1: Repository exists.
+- #AC2: Your Introducer has collaboration rights.

--- a/docs/legacy/modules/essentials/command-line-basics.md
+++ b/docs/legacy/modules/essentials/command-line-basics.md
@@ -1,0 +1,21 @@
+# Command Line Basics
+
+## Description
+
+In your daily work as a developer you will need to interact with a command line interface (CLI). Learn the basics in a gamified way by playing the Bandit-Game of[ OverTheWire](https://overthewire.org/wargames/bandit/).
+
+## Instructions
+
+Read the[ Instructions](https://overthewire.org/wargames/bandit/) of the Game, then start with Level 0. Use your Terminal to connect via ssh. You may need to use bash instead of zsh or other shells if you encounter problems.
+
+## Acceptance Criteria
+
+#AC1: Acquire the password for Level 11
+
+_Optional - #AC2: Acquire the password for Level 16_
+
+## Resources
+
+- Introduction to the Command Line:[ ](https://linuxjourney.com/lesson/the-shell)
+
+[Learning | Linux Journey](https://linuxjourney.com/lesson/the-shell)

--- a/docs/legacy/modules/essentials/introduction-to-docker.md
+++ b/docs/legacy/modules/essentials/introduction-to-docker.md
@@ -1,0 +1,21 @@
+# Introduction to Docker
+
+## Description
+
+Docker is a virtualization tool that reuses the host machine’s kernel and therefor avoids the overhead of virtual
+machines. Today, it is common practice to deploy software as docker images. To learn the basics of docker, complete the
+course [Docker Training Course for the Absolute Beginner | KodeKloud](https://kodekloud.com/courses/docker-for-the-absolute-beginner/).
+
+## Instructions
+
+Create an account at kodekloud and enroll for the free
+course [Docker Training Course for the Absolute Beginner | KodeKloud](https://kodekloud.com/courses/docker-for-the-absolute-beginner/).
+If you are already familiar with docker, skip the videos but make sure to complete the labs.
+
+## Prerequisites
+
+- [Command Line Basics](/legacy/modules/essentials/command-line-basics.md)
+
+## Acceptance Criteria
+
+- #AC1: Complete all labs of the course

--- a/docs/legacy/modules/essentials/learn-git-branching.md
+++ b/docs/legacy/modules/essentials/learn-git-branching.md
@@ -1,0 +1,16 @@
+# Learn Git Branching
+
+## Description
+
+Git is a version control tool. It tracks changes of you files and lets you easily revert them to a previous state. Git is an essential tool and you will probably use it on a daily basis.
+
+Learn the fundamentals Git branching by absolving [Learn Git Branching](https://learngitbranching.js.org/?locale=en_US).
+
+## Acceptance Criteria
+
+- #AC1: Complete all levels of main section
+- #AC2: Complete all levels of remote section
+
+## Resources
+
+[Learn the Basics of Git in Under 10 Minutes](https://www.freecodecamp.org/news/learn-the-basics-of-git-in-under-10-minutes-da548267cc91/)

--- a/docs/legacy/modules/index.md
+++ b/docs/legacy/modules/index.md
@@ -1,0 +1,21 @@
+# Modules
+
+## What is a Module?
+
+A module is an action-based task with the goal to learn topics of the Apprentice Checklist. If you previously have worked with Scrum, you can compare a module to a story.
+
+**It consists of**
+
+- a precise description of requirements.
+
+- a list of acceptance criteria.
+
+- a list of prerequisites (optional)
+
+**What it's not**:
+
+- A list of articles you should read.
+
+- Something like: “Learn Mockito”
+
+_(Both examples have its place…which is the Apprentice Checklist)_

--- a/docs/legacy/modules/katas/java-8-streams.md
+++ b/docs/legacy/modules/katas/java-8-streams.md
@@ -1,0 +1,20 @@
+# Java 8 Streams
+
+## Prerequisites
+
+- Create Kata Repository
+
+## Description
+
+Checkout the Java 8 Stream kata and copy it into your own kata repository. Make all tests green by transforming the Java 7 solutions into valid Java 8 solutions using streams. Compare your code with the Solution.
+
+## Acceptance Criteria
+
+- #AC1: All tests are green.
+- #AC2: Kata is committed & pushed to your own kata repository.
+
+## Helpful Resources
+
+Functional Programming with Java Streams API
+
+A Guide to Java Streams in Java 8: In-Depth Tutorial With Examples

--- a/docs/legacy/modules/katas/mars-rover.md
+++ b/docs/legacy/modules/katas/mars-rover.md
@@ -1,0 +1,52 @@
+# Mars Rover
+
+## Description
+
+You work at Twitter as part of the team that explores Mars by sending
+remotely controlled vehicles to the surface of the planet.
+
+### Requirements
+
+- Your Mars Rover gets initialized with a starting Point (x,y) and a
+  direction (N, S, E, W).
+- You have an unlimited grid... which means you can ignore the
+  grid completely.
+- Your Mars Rover accepts a String of commands:
+
+  - `L` for turning left.
+  - `R` for turning right.
+  - `M` for moving forward.
+
+- Multiple Obstacles exist on the grid
+
+  - Obstacles have Points like the Mars Rover.
+  - An Obstacle occupies the space of its position.
+  - Command `L` and `R` are not effected by obstacles.
+  - If the current executed command is `M`, but an obstacle block s
+    the way, nothing happens (command gets ignored) until a
+    following command (like `L` or `R`) occurs.
+
+- Example 1:
+
+  - Mars Rover starts at Point (0,0) with Direction North (N), no
+    obstacles.
+  - Input is `MMLMRMRMMR`.
+  - After executing command Mars Rover will be at Point (1,3)
+    heading South (S).
+
+- Example 2:
+
+  - Mars Rover starts at Point (1,0) with Direction North (N).
+  - Two obstacles on (1,2) and (2,3).
+  - Input is `MMMMRM`.
+  - After executing command Mars Rover will be at Point (2, 1)
+    heading East (E).
+
+### Constraints
+
+- besides TDD no constraints, just try to find a solution by yourself
+
+## Acceptance Criteria
+
+- **#AC1:** Code is covered with tests
+- **#AC2:** Kata is committed & pushed to your own kata repository.

--- a/docs/legacy/modules/todo-app.md
+++ b/docs/legacy/modules/todo-app.md
@@ -1,0 +1,3 @@
+# Get started with Full-Stack Development in a Scrum setup.
+
+Learn the basics of Typescript, Vue3, Spring Boot, Databases, Docker and CI/CD by creating an example ToDo-App.

--- a/docs/legacy/modules/todo-app/add-json-mock-server-for-frontend.md
+++ b/docs/legacy/modules/todo-app/add-json-mock-server-for-frontend.md
@@ -1,0 +1,49 @@
+# Add JSON Mock-Server for Frontend
+
+## Description
+
+We are getting to the Point where we can connect our Frontend with a potential Backend. To to so, instead of using
+hard-coded data, our tasks must be fetched from a server. To enable parallel development of Frontend & Backend and also
+to separate their dependence, a mock-server is used.
+
+This server acts as a dumb Backend and responds with predefined payloads.
+
+## Instructions
+
+- Install[ json-server](https://github.com/typicode/json-server) package as
+  a[ dev-dependency](https://github.com/typicode/json-server#simple-example).
+- Create a new directory for your mock-data and add a file called `db.json`.
+- Define[ routes](https://github.com/typicode/json-server#routes) with meaningful names. You need:
+  - `GET` to request all tasks
+  - `PUT` to update existing task
+  - `POST` to create new task
+  - `DELETE` to delete existing task
+- Define dummy response data
+- Start your mock-server and test all endpoints manually witch `curl` or similar tools
+- The `db.json` shall be committed to git. You may observed that calling `PUT`, `POST` or `DELETE` mutates the the file.
+  - Find a (simple) way to use all http requests while preventing the `db.json` from changing.
+- Create an npm script to make it as easy as possible for colleague developers to work the mock-server.
+- Adjust your Vue-App to fetch data
+  - You may realize that you tasks need an `id` to be uniquely identifiable. Add an id to your data structure if not
+    already happend.
+- Adapt you Cypress test to work again. You will have to[ intercept](https://docs.cypress.io/api/commands/intercept)
+  requests.
+
+## Prerequisites
+
+- [Ensure Green Tests and Code Quality of Frontend with CI](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2328199293)
+
+## Acceptance Criteria
+
+#AC1: Frontend fetches data instead of hard-coding it
+
+#AC2: Mock-Server intercepts all Requests from Frontend
+
+#AC3: App is still usable & Pipeline stays green (obviously)
+
+#AC4: Npm run script exists to easily start the mock-server
+
+## Resources
+
+- [GitHub - typicode/json-server: Get a full fake REST API with zero coding in less than 30 seconds (seriously)](https://github.com/typicode/json-server)
+- [intercept | Cypress Documentation](https://docs.cypress.io/api/commands/intercept)

--- a/docs/legacy/modules/todo-app/connect-frontend-with-backend.md
+++ b/docs/legacy/modules/todo-app/connect-frontend-with-backend.md
@@ -1,0 +1,29 @@
+# Connect Frontend with Backend
+
+## Description
+
+Now the wedding can happen. Create an endpoint for every request of your Frontend. At the end of this story, you should
+be able to use your application with all its features…although the data isn’t persisted between application restarts.
+
+## Instructions
+
+- Create a new WebMVC Controller class.
+- Add endpoints for every Frontend request.
+- For now, return hard-coded response data. Soon we will persist tasks in a database.
+- Adapt your Vite config to work with real backend and JSON mock-server
+
+## Prerequisites
+
+- [Initial Spring Boot Backend](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2329018373)
+
+## Acceptance Criteria
+
+- #AC1: Endpoint exists for `GET` , `PUT` , `POST` and `DELETE`
+
+- #AC2: Frontend still works independently from backend in conjunction with JSON mock-server
+
+- #AC3: Frontend works when served with backend
+
+## Resources
+
+- [Spring Boot CRUD Application with Thymeleaf | Baeldung](https://www.baeldung.com/spring-boot-crud-thymeleaf#bd-the-controllers-layer)

--- a/docs/legacy/modules/todo-app/create-github-repo.md
+++ b/docs/legacy/modules/todo-app/create-github-repo.md
@@ -1,0 +1,17 @@
+# Create GitHub Repository
+
+## Description
+
+Create a GitHub Repository with your personal klose brother GitHub Account for the ToDo-App.
+
+## Acceptance Criteria
+
+#AC1: Github repository exists
+
+#AC2: Mentor has read/write access to repository
+
+#AC3: Following files exist:
+
+`Readme.md` with short description about project
+
+`.gitignore`, which ignores `.idea` directory

--- a/docs/legacy/modules/todo-app/create-initial-vue3-frontend.md
+++ b/docs/legacy/modules/todo-app/create-initial-vue3-frontend.md
@@ -1,0 +1,49 @@
+# Create initial Vue3 Frontend
+
+## Description
+
+Create a fresh Vue3 app with Vite. Vite is a bundling-tool & Dev Server for Frontend development and currently the
+recommended way of creating Vue3 projects.
+
+## Prerequisites
+
+- [Create GitHub Repository](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2328199195)
+
+## Acceptance Criteria
+
+- #AC1: Vue3 App exist in its own directory with latest NodeJs LTS
+  _(have a look
+  at[ nvm](https://github.com/nvm-sh/nvm) /[ nvm for windows](https://github.com/coreybutler/nvm-windows))_
+
+- #AC2: Following tooling is added (select during install):
+  _(not all tooling will be used for our todo-app)_
+
+  - Typescript
+  - Vue Router
+  - Pinia
+  - Vitest
+  - End-to-End Testing: Cypress
+  - EsLint
+  - Prettier
+
+- #AC3: Code is formatted correctly
+
+  - Generate reasonable config with[ Prettier Config Generator](https://michelelarson.com/prettier-config/)
+
+  - replace `.prettier.json` with own config
+  - enable Prettier for project in IntelliJ
+  - reformat whole Frontend code
+
+- #AC4: `.gitignore` exists which ignores the build directory of Vite
+
+- #AC5: Commit messages have format: _(this commit will)_ `add initial frontend` , where part in brackets is omitted
+
+## Resources
+
+- [Vue.js](https://vuejs.org/guide/scaling-up/tooling.html#vite)
+
+- [Why Vite](https://vitejs.dev/guide/why.html)
+
+- [GitHub - nvm-sh/nvm: Node Version Manager - POSIX-compliant bash script to manage multiple active node.js versions](https://github.com/nvm-sh/nvm)
+
+- [GitHub - coreybutler/nvm-windows: A node.js version management utility for Windows. Ironically written in Go.](https://github.com/coreybutler/nvm-windows)

--- a/docs/legacy/modules/todo-app/database-management-with-liquibase.md
+++ b/docs/legacy/modules/todo-app/database-management-with-liquibase.md
@@ -1,0 +1,30 @@
+# Database Management with Liquibase
+
+## Description
+
+It is likely that the data we want to persist will change in future. We may want to add additional columns in our tables
+or save user information. We may also want to change our database from lets say MySQL to PostgreSQL. Executing these
+changes via scripts of SQL statements is hard to track and reproduce. Also, the syntax differ between databases.
+
+Liquibase provides a solution to this problem and is widely used in Java Applications.
+
+## Instructions
+
+- Add Liquibase Core as maven dependency
+- Enable Liquibase in your `application.properties` and set the path to a change-log file
+- Fill your tasks table with test data via Liquibase.
+  - Create a new changeset which inserts test data into the tasks table
+  - This changeset shall only be executed with the dev profile. We do not want test data on production
+
+## Prerequisites
+
+- [Persist Data with In-Memory Database](/legacy/modules/todo-app/persist-data-with-in-memory-database.md)
+
+## Acceptance Criteria
+
+- #AC1: Backend uses Liquibase
+- #AC2: Test data exists for task and only for dev profile
+
+## Resources
+
+- [Use Liquibase to Safely Evolve Your Database Schema | Baeldung](https://www.baeldung.com/liquibase-refactor-schema-of-java-app)

--- a/docs/legacy/modules/todo-app/dockerize-the-app.md
+++ b/docs/legacy/modules/todo-app/dockerize-the-app.md
@@ -1,0 +1,30 @@
+# Dockerize the App
+
+## Description
+
+We are getting closer to deploying our app. You may noticed that it has multiple dependencies. We need the Frontend to
+build and then place into the correct directory. We then need our backend built and packaged. In future, the app might
+have additional dependencies like global libraries or other services.
+
+Create a multi-stage Docker file for our app which handles the complete build process. If you satisfy the prerequisites
+you should have a basic understanding of Docker.
+
+## Instructions
+
+- Create a docker file.
+- Add a stage for the maven build.
+  - Depending on how you build the Frontend, you may want to add another stage for the Vite build with its
+    dependencies.
+- Copy the build result into the final stage.
+- Choose fitting base images for each stage.
+- The Docker file must not rely on previously build targets in your output directories.
+- Test your file by building and running it. Expose the internal port.
+
+## Prerequisites
+
+- [Introduction to Docker](/legacy/modules/essentials/introduction-to-docker.md)
+- [Database Management with Liquibase](/legacy/modules/todo-app/database-management-with-liquibase.md)
+
+## Acceptance Criteria
+
+- #AC1: Docker file exists which successfully builds app in a freshly cloned repository

--- a/docs/legacy/modules/todo-app/ensure-green-tests-and-code-quality.md
+++ b/docs/legacy/modules/todo-app/ensure-green-tests-and-code-quality.md
@@ -1,0 +1,43 @@
+# Ensure Green Tests and Code Quality
+
+## Description
+
+We want to enforce that new code does not break existing tests and complies to our formatting rules. To do this we need
+Continuous Integration (CI). In detail, we want to create a pipeline which automatically validates our tests and code.
+
+## Instructions
+
+- Create a new GitHub Action Workflow that gets triggered on Push\
+  _Be aware that the `main` branch would normally be protected and changes can only be made through
+  Pull-Requests. In this case the trigger should be Pull-Request. Unfortunately, the GitHub free account does not
+  allow branch protection._
+- [Checkout](https://github.com/actions/checkout) the code.
+- Chose one of the ACs and try to create the workflow for it. You may use GitHub’s workflow templates during creation.
+- Validate both cases: Passing and Failing.
+  - e.g.: Push changes which violate EsLint rules (e.g. `const bla;` → const declaration without
+    assignment) and check if Pipeline fails.
+- Continue with the other ACs.
+- **Tipp:** ChatGPT is pretty good in creating simple Workflows.
+
+## Prerequisites
+
+- [Frontend Testing with Cypress](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2328494120)
+
+## Acceptance Criteria
+
+- #AC1: GitHub Actions Workflow exists and gets triggered on every push to the `main` branch
+
+- #AC2: Workflow executes all Cypress tests
+
+- #AC3: Workflow checks EsLint rules
+
+- #AC4: Workflow checks Prettier formatting
+
+## Resources
+
+- [What is Continuous Integration?](https://aws.amazon.com/devops/continuous-integration)
+
+* [Understanding GitHub Actions - GitHub Docs](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions)
+
+- Check Formatting:[ ](https://prettier.io/docs/en/cli.html#--check)
+  [CLI · Prettier](https://prettier.io/docs/en/cli.html#--check)

--- a/docs/legacy/modules/todo-app/frontend-testing-with-cypress.md
+++ b/docs/legacy/modules/todo-app/frontend-testing-with-cypress.md
@@ -1,0 +1,33 @@
+# Frontend Testing with Cypress
+
+## Description
+
+To ensure that our Frontend works as expected even after future changes we want to
+add[ Cypress](https://www.cypress.io/). Cypress is testing tool for Component and End-to-End tests.
+
+## Instructions
+
+- Cypress should already be[ installed](https://docs.cypress.io/guides/getting-started/installing-cypress) during Vite
+  installation, if not do it now.
+- Add new test which:
+  - navigates to your App
+  - validates all static text
+  - adds multiple tasks and validates their creation
+  - edits one task and validates change
+  - deletes another task and validates deletion
+
+## Prerequisites
+
+- [Implement UI Design](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2328330313)
+
+## Acceptance Criteria
+
+- #AC1: Test exists which valides creation, editing and deletion of task
+
+- #AC2: NPM run script exists to execute cypress in headless mode from console
+
+## Resources
+
+- [Effective E2E: Cypress App Testing | Cypress Documentation](https://docs.cypress.io/guides/end-to-end-testing/testing-your-app)
+- [Command Line | Cypress Documentation](https://docs.cypress.io/guides/guides/command-line)
+- [ Creating "Tiny" Tests With A Single Assertion](https://docs.cypress.io/guides/references/best-practices#Creating-Tiny-Tests-With-A-Single-Assertion)

--- a/docs/legacy/modules/todo-app/implement-ui-design.md
+++ b/docs/legacy/modules/todo-app/implement-ui-design.md
@@ -1,0 +1,40 @@
+# Implement UI Design
+
+1.
+
+## Description
+
+Create the implementation for the Frontend according to
+the[ Figma Design](https://www.figma.com/file/fvqm3N7ucOGdHAFm0IdTO5/ToDo-App-New?type=design&node-id=1%3A571&mode=design&t=QAi9yGnZ5lPRrwZE-1).
+At the end of this story you should be able to add, edit and delete tasks.
+
+## Instructions
+
+- For this story, all data only exists in the Frontend. Use
+  simple[ vue-refs](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#declaring-reactive-state-1) for your
+  state. No need to fetch data from a mock-server, at this point.
+- Use Composition-API instead of Options-API
+- Try to implement the Frontend in a modular way. Create small, easy to use components and compose bigger components out
+  of them.
+- Add TS-Types for data and add type signatures to your functions.
+
+## Prerequisites
+
+- [Create initial Vue3 Frontend](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2328297528)
+
+## Acceptance Criteria
+
+- #AC1: UI exists according to UI Design
+
+- #AC2: Customer can add Todo-Task (FE only)
+
+- #AC3: Customer can edit Todo-Task (FE only)
+
+- #AC4: Customer can delete Todo-Task (FE only)
+
+## Resources
+
+- [ToDo-App](https://www.figma.com/file/QOw0YxLtQK5VZrK8HllVHD/ToDo-App?type=design&mode=design&t=MmWri7qtOgwQsT3S-1) UI
+  Design
+- [Vue.js](https://vuejs.org/guide/essentials/reactivity-fundamentals.html)
+- [Vue.js](https://vuejs.org/guide/typescript/composition-api.html)

--- a/docs/legacy/modules/todo-app/index.md
+++ b/docs/legacy/modules/todo-app/index.md
@@ -1,0 +1,5 @@
+# ToDo-App
+
+Get started with Full-Stack Development in a Scrum setup.
+
+Learn the basics of Typescript, Vue3, Spring Boot, Databases, Docker and CI/CD by creating an example ToDo-App.

--- a/docs/legacy/modules/todo-app/initial-spring-boot-backend.md
+++ b/docs/legacy/modules/todo-app/initial-spring-boot-backend.md
@@ -1,0 +1,49 @@
+# Add JSON Mock-Server for Frontend
+
+## Description
+
+We are getting to the Point where we can connect our Frontend with a potential Backend. To to so, instead of using
+hard-coded data, our tasks must be fetched from a server. To enable parallel development of Frontend & Backend and also
+to separate their dependence, a mock-server is used.
+
+This server acts as a dumb Backend and responds with predefined payloads.
+
+## Instructions
+
+- Install[ json-server](https://github.com/typicode/json-server) package as
+  a[ dev-dependency](https://github.com/typicode/json-server#simple-example).
+- Create a new directory for your mock-data and add a file called `db.json`.
+- Define[ routes](https://github.com/typicode/json-server#routes) with meaningful names. You need:
+  - `GET` to request all tasks
+  - `PUT` to update existing task
+  - `POST` to create new task
+  - `DELETE` to delete existing task
+- Define dummy response data
+- Start your mock-server and test all endpoints manually witch `curl` or similar tools
+- The `db.json` shall be committed to git. You may observed that calling `PUT`, `POST` or `DELETE` mutates the the file.
+  - Find a (simple) way to use all http requests while preventing the `db.json` from changing.
+- Create an npm script to make it as easy as possible for colleague developers to work the mock-server.
+- Adjust your Vue-App to fetch data
+  - You may realize that you tasks need an `id` to be uniquely identifiable. Add an id to your data structure if not
+    already happend.
+- Adapt you Cypress test to work again. You will have to[ intercept](https://docs.cypress.io/api/commands/intercept)
+  requests.
+
+## Prerequisites
+
+- [Ensure Green Tests and Code Quality of Frontend with CI](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2328199293)
+
+## Acceptance Criteria
+
+- #AC1: Frontend fetches data instead of hard-coding it
+
+- #AC2: Mock-Server intercepts all Requests from Frontend
+
+- #AC3: App is still usable & Pipeline stays green (obviously)
+
+- #AC4: Npm run script exists to easily start the mock-server
+
+## Resources
+
+- [GitHub - typicode/json-server: Get a full fake REST API with zero coding in less than 30 seconds (seriously)](https://github.com/typicode/json-server)
+- [intercept | Cypress Documentation](https://docs.cypress.io/api/commands/intercept)

--- a/docs/legacy/modules/todo-app/persist-data-with-in-memory-database.md
+++ b/docs/legacy/modules/todo-app/persist-data-with-in-memory-database.md
@@ -1,0 +1,47 @@
+# Persist Data with In-Memory Database
+
+## Description
+
+Currently, all tasks added to the Backend via the Frontend are removed after restart. For production, we need to persist
+this data with a database. A first step to close the gap between our current implementation and production is to use an
+in-memory database. We will use [H2](https://www.h2database.com/html/main.html) for that purpose.
+
+## Instructions
+
+- Add following maven dependencies:
+  - H2 Database
+  - Spring Boot Starter Data JPA
+- Create a new Spring profile in `src/main/resources` and call it `application-dev.properties`.
+  - Enable the H2 console.
+  - Add necessary entries for JPA and H2 to work.
+  - Add the newly created `dev` profile to your IntelliJ run configuration under.
+- Create a new Entity class for your Task named `TaskEntity` and define necessary fields.
+- Use Lombok to avoid Boilerplate code.
+- Create a JPA Repository for your Entity and call it `TaskRepository`.
+- Create a Service class and call it `TaskService` .
+- Adapt your Controller endpoints to use the database.
+  - Your endpoint, only calls a method of the Service.
+  - The Service calls the Repository to interact with the database. It yields `TaskEntity` objects.
+  - If the endpoint shall return a response body, create a POJO called `Task` out of your TaskEntity inside your
+    Service. It should be immutable. Return this object to the Controller.
+  - Create a DTO object out of your `Task` object called `TaskDto` inside your Controller. It should be immutable.
+    Return it to generate a response body.
+- This segmentation is obviously overkill for our app, but the whole purpose of creating the ToDo-App is learning. The
+  advantage of this separation is flexibility _(with the cost of additional abstraction)_.
+- Start your app and test it manually. Validate the changes of your database with the h2-console under
+  `http://localhost:8080/h2-console`.
+
+## Prerequisites
+
+- [Connect Frontend with Backend](/legacy/modules/todo-app/connect-frontend-with-backend.md)
+
+## Acceptance Criteria
+
+- #AC1: Backend persists data with In-Memory database
+
+## Resources
+
+- [Spring Boot With H2 Database | Baeldung](https://www.baeldung.com/spring-boot-h2-database)
+- [Introduction to Project Lombok | Baeldung](https://www.baeldung.com/intro-to-project-lombok#bd-constructors)
+- [DTO Pattern](https://www.baeldung.com/java-dto-pattern)
+- [Java Record Keyword | Baeldung](https://www.baeldung.com/java-record-keyword)

--- a/docs/legacy/objectives.md
+++ b/docs/legacy/objectives.md
@@ -1,0 +1,222 @@
+# Objectives
+
+## Languages
+
+### Java
+
+- Streams
+- Records
+- Optional's
+- Generics
+- Function Interfaces
+  - `Function`, `BiFunction`, `Consumer`, `Supplier`
+
+### Typescript
+
+- `keyof`, `typeof`
+- `Partial`, `Required`, `Readonly`, `Record`, `Omit`, `Exclude`, `ReturnType`
+
+### **SQL**
+
+- Know existence of different dialects
+- Query data with `SELECT`, `FROM`, `ORDER BY`, `DESC`, `ASC`, `LIMIT`, `DISTINCT`
+- Filter Data
+  - with `WHERE`, `IN`, `LIKE`, `AND`, `NOT LIKE`
+  - filter on multiple columns
+  - on missing data with `IS NULL` / `IS NOT NULL`
+- Aggregating Data with `SUM`, `AVG`, `MAX`, `MIN`
+- Join Tables with `INNER JOIN`, `LEFT JOIN`, `RIGHT JOIN`, `FULL JOIN`
+
+## Frameworks / Libraries
+
+### **Spring Boot**
+
+- Spring Framework
+  - Core
+    - Use `@Component`, `@Bean` & `@Service`
+    - Understand `@Autowired`
+    - Null-safety with `@Nullable` & `@NonNull`
+    - Logging with Spring
+    - Mock Beans with `@MockBean`
+  - Web MVC
+    - Create Controller Endpoint
+    - Return different Status Codes
+    - Test Endpoints with MockMVC
+- Spring Data
+  - Create Entity
+  - Create OneToMany Relation
+  - Cascade Deletion for OneToMany
+  - Create Repository
+  - Create JPA interface function
+  - Create custom query
+  - Create Repository Test
+
+### **Vue3**
+
+- Composition API
+- Use Typescript with Vue
+- Understand Reactivity
+- `ref`
+- `computed`
+- Pass Props
+- Conditional classes & styles
+- Event handling
+- Use & design Slots
+- Fetch data
+- Use Composables
+- Routing with `vue-router`
+- Create pages
+- Use `<RouterLink>`
+- Use `<RouterView>` slot
+- Browser Plugin `Vue DevTools`
+
+### **Mockito**
+
+- Mock services with `Mockito.when`
+- Verify interaction with `Mockito.verify`
+
+### **JUnit**
+
+- `@Test`, `@ParameterizedTest`, `@RepeatedTest`, `@Disabled`
+- `@DisplayName`, `@DisplayNameGeneration`
+- `@BeforeEach`, `@AfterEach`, `@BeforeAll`, `@AfterAll`
+
+### **AssertJ**
+
+- Common Assertions on type
+- Collection Assertions
+- Assertions on Exceptions
+
+## Tools
+
+### **Insomnia**
+
+- Create Requests
+- Send Request Body
+- Use Query Params
+- Use Path Variables
+- Use Environments
+
+### **Chrome**
+
+- AdBlock
+- DarkReader
+- Vimium
+- JSONVue
+
+### **Git**
+
+- set commit username & email
+- initialize or clone repository
+- stage changes with `git` [ `status`, `add`, `reset`, `diff`, `commit` ]
+- branches: create, checkout & merge branches
+- share & update with `git` [ `remote add`, `fetch`, `push`, `pull` ]
+- fundamentals of `git rebase`
+- IntelliJ’s git shelve
+
+### **IntelliJ**
+
+- Shortcuts
+- Settings & Plugin Sync
+- Plugins
+  - CheckStyle-IDEA
+  - Key Promoter X
+  - Presentation Assistant
+  - Sonarlint
+  - String Manipulation
+  - AsciiDoc
+
+### **Maven**
+
+- Lifecycles
+- Add dependencies
+- IntelliJ Maven Tool Window
+
+### **NPM**
+
+- Add package
+- Add custom script
+
+### **Docker**
+
+- Image
+  - build with tag
+  - list all images
+  - remove single image and all unused images
+- Container
+  - run container from image with custom name
+  - publish port to the host
+  - run container in background
+  - start / stop container
+  - remove stopped container
+  - open shell inside container
+  - show logs of container
+  - list running / all containers
+- Dockerfile
+  - `FROM`, `ENV`, `RUN`,
+  - `WORKDIR`, `COPY`, `ADD`
+  - `CMD`, `ENTRYPOINT`
+
+### **GitHub Actions**
+
+- TODO
+
+### **Command Line**
+
+## Methodology
+
+### **Coding**
+
+- Pair Programming
+  - Driver / Navigator
+  - Constraints
+- Mob Programming
+- Time Management with Pomodoro
+
+### **Scrum Roles**
+
+- Developer
+- Product Owner
+- Scrum Master
+
+### **Scrum Meetings**
+
+- **Daily **- in 1 minute say:
+  - **what have I** done recently?
+  - **what will I** work on today?
+  - **what is preventing **me from working?
+- **Review** - how do I present the achievements of the last sprint? \
+  Focus on results/”done” stories, and the created customer value. \
+  Talk about the solutions you delivered, not problems you encountered!
+- **Planning** - estimate what we can achieve in the next sprint? \
+  What is realistic, what not?
+- **Retro **- adapt for the next sprint
+  - moderate one retro in v-team \
+    Consider the different phases to activate the participants, collect insights and define action steps
+  - participate in retros: \
+    Talk about things that reduced your productivity or satisfaction, talk about what bothers you, and what should be different in the future. \
+    Goal: **Define action steps **for all or some team members for the next sprint. \
+    NOT the goal: Vent (or rant) about a topic.
+
+### **Work ethics**
+
+- **Think in solutions, not problems**
+  - When faced with a difficult situation (technical, structural, personal,...) think about what you can do. \
+    Collect possible solutions, discuss them, choose one and implement it.
+  - If someone drifts into complaining about things that do not go well, remind that person that things won't change if you just complain about it (Note that this is a "problem thinking" sentence! Complaining about someone who is complaining does not solve anything!)
+  - Instead: \
+    If someone drifts into complaining about things that do not go well, remind that person that things will (only) change, if you adapt and approach the current task/situation differently. (This is "solution thinking". It might help the complaining person to step into solution-mode)
+- **Always be polite and honest \
+  **But also don't be too polite (and let everything be done to you).
+  - If something is going wrong or someone is acting in a bad or destructive way, communicate your perception. Do not close your eyes to something and suffer in silence.
+  - Consider using the retro to talk about "bigger topics", and keep in mind to not take everything personal or too serious.
+- **Transparency \
+  **Your PO or other team members will highly appreciate if you tell them a task will take unexpectedly longer - instead of hiding it until a lot of time has passed.
+- **Activity**
+  - Don't just sit and listen in meetings. Be part of the active discussion.
+  - OR: Ask politely if you may leave/skip the meeting if you think your time could be used more wisely. Usually, no one will force you to attend a meeting if your attentance has no benefit for the customer.
+
+## Certifications
+
+- CSM: Certified Scrum Master
+- CSD: Certified Scrum Developer

--- a/docs/legacy/roadmap.md
+++ b/docs/legacy/roadmap.md
@@ -1,0 +1,44 @@
+# Roadmap
+
+## Goal
+
+The main goal of our Apprentice program is to become project-ready. This means the Apprentice has a fundamental
+understanding of Full-Stack-Development.
+
+## Timeline
+
+The time to complete the Apprentice Project is roughly set to 12 weeks full-time plus the time for the project
+internship.
+
+## Content
+
+The Mentor should adapt the content and structure of the Apprentice Programm to the Apprentice. Nonetheless it makes
+sense to follow the basic structure described here.
+
+### **1. Week**
+
+- First Week Checklist[ ↳](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2310078489)
+- Kata / Project Parings to find a Mentor
+
+### **2. Week**
+
+- Kata / Project Parings
+- Fundamental Modules: Katas, Command Line, Git, Docker …
+
+### **3. - 6. Week**
+
+- Todo-App[ ↳](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2328166409)
+
+### **7. - 12. Week**
+
+- Apprentice Project[ ↳](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2209841153)
+
+### **In Between**
+
+- CSM, CSD
+- Apprentice Sync[ ↳](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2184642561)
+- Reading one Book (free-time)
+
+### **After Apprentice Project**
+
+- Project Internship


### PR DESCRIPTION
We copied the legacy confluence/atlassian pages into the project and migrated them to `.md` files. The folder structure has been preserved. Some minor typos were fixed on the fly.