### PR TITLE
feat: fix duplicate page (initial-spring-boot-backend was missing)

### DIFF
--- a/docs/legacy/modules/todo-app/initial-spring-boot-backend.md
+++ b/docs/legacy/modules/todo-app/initial-spring-boot-backend.md
@@ -1,49 +1,38 @@
-# Add JSON Mock-Server for Frontend
+# Initial Spring Boot Backend
 
 ## Description
 
-We are getting to the Point where we can connect our Frontend with a potential Backend. To to so, instead of using
-hard-coded data, our tasks must be fetched from a server. To enable parallel development of Frontend & Backend and also
-to separate their dependence, a mock-server is used.
-
-This server acts as a dumb Backend and responds with predefined payloads.
+To offer customers a way to persist & access their tasks we need a backend. Create a fresh Spring Boot Application.
 
 ## Instructions
 
-- Install[ json-server](https://github.com/typicode/json-server) package as
-  a[ dev-dependency](https://github.com/typicode/json-server#simple-example).
-- Create a new directory for your mock-data and add a file called `db.json`.
-- Define[ routes](https://github.com/typicode/json-server#routes) with meaningful names. You need:
-  - `GET` to request all tasks
-  - `PUT` to update existing task
-  - `POST` to create new task
-  - `DELETE` to delete existing task
-- Define dummy response data
-- Start your mock-server and test all endpoints manually witch `curl` or similar tools
-- The `db.json` shall be committed to git. You may observed that calling `PUT`, `POST` or `DELETE` mutates the the file.
-  - Find a (simple) way to use all http requests while preventing the `db.json` from changing.
-- Create an npm script to make it as easy as possible for colleague developers to work the mock-server.
-- Adjust your Vue-App to fetch data
-  - You may realize that you tasks need an `id` to be uniquely identifiable. Add an id to your data structure if not
-    already happend.
-- Adapt you Cypress test to work again. You will have to[ intercept](https://docs.cypress.io/api/commands/intercept)
-  requests.
+- Create a fresh Spring Boot Application either with IntelliJ or [Spring Initilizr](https://start.spring.io/).
+  - Select current Java LTS version
+  - Select following Spring Dependencies
+    - Spring Web (allows to create web-server)
+    - _(we will need more, but for now, that’s sufficient)_
+- Explicitly set the port to `8080` in `src/main/resources/application.properties`.
+- Start the backend. You should see console output without errors.
+- By default, Spring serves everything in its `src/main/resources/static` directory.
+  - Manually build your Frontend (_look into your_ `package.json`) and copy the output into Springs `static` directory.
+  - Stop every npm script and start your backend. You should now be able to access your Frontend via port `8080`.
+- Now find a way to skip this ‘manually copy’ step by automatically copy the Frontend into the static directory in an easy to use way.
+- It is correct that requests resolve in 404 error, because currently no endpoint exists in the backend.
 
 ## Prerequisites
 
-- [Ensure Green Tests and Code Quality of Frontend with CI](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2328199293)
+- [Add JSON Mock-Server for Frontend](https://klosebrothers.atlassian.net/wiki/spaces/KB/pages/2328756229)
 
 ## Acceptance Criteria
 
-- #AC1: Frontend fetches data instead of hard-coding it
-
-- #AC2: Mock-Server intercepts all Requests from Frontend
-
-- #AC3: App is still usable & Pipeline stays green (obviously)
-
-- #AC4: Npm run script exists to easily start the mock-server
+- [ ] #AC1: Backend as Spring Boot Application with current Java LTS exists
+- [ ] #AC2: Backend serves Frontend
 
 ## Resources
 
-- [GitHub - typicode/json-server: Get a full fake REST API with zero coding in less than 30 seconds (seriously)](https://github.com/typicode/json-server)
-- [intercept | Cypress Documentation](https://docs.cypress.io/api/commands/intercept)
+- [What is Spring Framework? | Definition from TechTarget](https://www.techtarget.com/searchapparchitecture/definition/Spring-Framework)
+- [What Is Java Spring Boot? | IBM](https://www.ibm.com/topics/java-spring-boot)
+
+- Copy Frontend into static directory. Ideas:
+  - [Apache Maven Resources Plugin – Introduction](https://maven.apache.org/plugins/maven-resources-plugin/)
+  - [Vite build.outDir](https://vitejs.dev/config/build-options.html#build-outdir)


### PR DESCRIPTION
replaced the content of one page that was added twice ("add json mock" page) by the content that was missing ("initial spring boot" page)